### PR TITLE
Fixed broken image link

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -17,7 +17,7 @@ If you're wondering how to contribute to the project, please refer to [CONTRIBUT
 ## License
 
 <p align="left">
-  <img width="40%" src="https://github.com/dahliaos/brand/blob/master/Logo%20PNGs/dahliaOS%20logo%20with%20text%20(drop%20shadow).png"
+  <img width="40%" src="https://github.com/dahliaOS/brand/blob/master/dahliaOS/svg/logotypeblacktext.svg"
 </p>
 
 Copyright @ 2019-2021 The dahliaOS Authors contact@dahliaos.io


### PR DESCRIPTION
## Description

The link to the logo under the License section was broken. Replaced the broken link with the new one. The logo image now shows up in the README file.

## Screenshots

Before: 
![image](https://user-images.githubusercontent.com/73262131/155919459-2b5dea98-0e83-49eb-b3e8-c6130264c4b6.png)

After: 
![image](https://user-images.githubusercontent.com/73262131/155919514-a4a999f0-7a48-4707-8936-5e7f8cb940bb.png)

## Type of change

Please tick the relevant option by putting an X inside the bracket

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] All current GitHub actions pass
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
- [X] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
